### PR TITLE
Added socks tests (in progress)

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/socks/internal/stream/client/ConnectReplyStreamHandler.java
+++ b/src/main/java/org/reaktivity/nukleus/socks/internal/stream/client/ConnectReplyStreamHandler.java
@@ -179,7 +179,7 @@ final class ConnectReplyStreamHandler extends AbstractStreamHandler
             limit = slotOffset;                                  //
         }
         // one negotiation request frame is in the buffer
-        if (context.socksNegotiationResponseRO.canWrap(buffer, offset, limit))
+        if (context.socksNegotiationResponseRO.canWrap(buffer, offset, limit)) 
         {
             // Wrap the frame and extract the incoming data
             final SocksNegotiationResponseFW socksNegotiationResponse =

--- a/src/main/java/org/reaktivity/nukleus/socks/internal/stream/client/ConnectReplyStreamHandler.java
+++ b/src/main/java/org/reaktivity/nukleus/socks/internal/stream/client/ConnectReplyStreamHandler.java
@@ -179,7 +179,7 @@ final class ConnectReplyStreamHandler extends AbstractStreamHandler
             limit = slotOffset;                                  //
         }
         // one negotiation request frame is in the buffer
-        if (context.socksNegotiationResponseRO.canWrap(buffer, offset, limit)) 
+        if (context.socksNegotiationResponseRO.canWrap(buffer, offset, limit))
         {
             // Wrap the frame and extract the incoming data
             final SocksNegotiationResponseFW socksNegotiationResponse =

--- a/src/test/java/org/reaktivity/nukleus/socks/internal/streams/forward/client/ConnectionIT.java
+++ b/src/test/java/org/reaktivity/nukleus/socks/internal/streams/forward/client/ConnectionIT.java
@@ -18,6 +18,7 @@ package org.reaktivity.nukleus.socks.internal.streams.forward.client;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
@@ -62,4 +63,53 @@ public class ConnectionIT
     {
         k3po.finish();
     }
+
+    @Ignore
+    @Test
+    @ScriptProperty({
+        "mode 'FORWARD'",
+        "serverAccept 'nukleus://target/streams/socks#source'"
+    })
+    @Specification({
+        "${route}/client/controller",
+        "${client}/client.does.not.connect.no.acceptable.methods/client",
+        "${server}/client.does.not.connect.no.acceptable.methods/server"
+    })
+    public void shouldNotEstablishConnectionNoAcceptableMethods() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Ignore
+    @Test
+    @ScriptProperty({
+        "mode 'FORWARD'",
+        "serverAccept 'nukleus://target/streams/socks#source'"
+    })
+    @Specification({
+        "${route}/client/controller",
+        "${client}/client.connect.fallback.to.no.authentication/client",
+        "${server}/client.connect.fallback.to.no.authentication/server"
+    })
+    public void shouldEstablishConnectionFallbackToNoAuthentication() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Ignore
+    @Test
+    @ScriptProperty({
+        "mode 'FORWARD'",
+        "serverAccept 'nukleus://target/streams/socks#source'"
+    })
+    @Specification({
+        "${route}/client/controller",
+        "${client}/client.connect.request.with.command.not.supported/client",
+        "${server}/client.connect.request.with.command.not.supported/server"
+    })
+    public void shouldNotEstablishConnectionCommandNotSupported() throws Exception
+    {
+        k3po.finish();
+    }
+
 }

--- a/src/test/java/org/reaktivity/nukleus/socks/internal/streams/forward/server/ConnectionIT.java
+++ b/src/test/java/org/reaktivity/nukleus/socks/internal/streams/forward/server/ConnectionIT.java
@@ -18,6 +18,7 @@ package org.reaktivity.nukleus.socks.internal.streams.forward.server;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
@@ -57,6 +58,48 @@ public class ConnectionIT
         "${client}/client.connect.send.data/client",
         "${server}/client.connect.send.data/server"})
     public void shouldAcceptAndSendDataBothWays() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Ignore
+    @Test
+    @ScriptProperty({
+        "mode 'FORWARD'"
+    })
+    @Specification({
+        "${route}/server/controller",
+        "${client}/client.does.not.connect.no.acceptable.methods/client",
+        "${server}/client.does.not.connect.no.acceptable.methods/server"})
+    public void shouldNotEstablishConnectionNoAcceptableMethods() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Ignore
+    @Test
+    @ScriptProperty({
+        "mode 'FORWARD'"
+    })
+    @Specification({
+        "${route}/server/controller",
+        "${client}/client.connect.fallback.to.no.authentication/client",
+        "${server}/client.connect.fallback.to.no.authentication/server"})
+    public void shouldEstablishConnectionFallbackToNoAuthentication() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Ignore
+    @Test
+    @ScriptProperty({
+        "mode 'FORWARD'"
+    })
+    @Specification({
+        "${route}/server/controller",
+        "${client}/client.connect.request.with.command.not.supported/client",
+        "${server}/client.connect.request.with.command.not.supported/server"})
+    public void shouldNotEstablishConnectionCommandNotSupported() throws Exception
     {
         k3po.finish();
     }


### PR DESCRIPTION
Added tests for the following scenarios:
- the server doesn't accept any of the methods listed by the client, so the client closes the connection (ConnectionIT.shouldNotEstablishConnectionNoAcceptableMethods)
- client sends in the request username&password as authentication method, but no authentication method will be used instead (ConnectionIT.shouldEstablishConnectionFallbackToNoAuthentication)
- client sends in the request a command that is not recognized, the server replies accordingly (ConnectionIT.shouldNotEstablishConnectionCommandNotSupported)